### PR TITLE
Check automatically Intel and Silicon MACS and minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,18 @@ override LDFLAGS += # Nothing
 ### On macOS, include <argp.h> from Homebrew package `argp-standalone`
 ifneq ($(OS),Windows_NT)
 	ifeq ($(shell uname -s),Darwin)
-                override CFLAGS  += -I/opt/homebrew/Cellar/argp-standalone/1.5.0/include/
-                override LDFLAGS += -L/opt/homebrew/Cellar/argp-standalone/1.5.0/lib/ -largp
+		UNAME_M := $(shell uname -m)
+		ifeq ($(UNAME_M),arm64)
+			# Apple Silicon
+			ARGP_PREFIX := /opt/homebrew/opt/argp-standalone
+		else ifeq ($(UNAME_M),x86_64)
+			# Intel Macs
+			ARGP_PREFIX := /usr/local/opt/argp-standalone
+		else
+			$(error Unsupported architecture $(UNAME_M))
+		endif
+		override CFLAGS  += -I$(ARGP_PREFIX)/include/
+		override LDFLAGS += -L$(ARGP_PREFIX)/lib/ -largp
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ override CFLAGS += \
 -Wall \
 -Wextra \
 -Wno-incompatible-pointer-types \
--Wno-multichar \
 -Wno-unused-variable \
+-Wno-unused-but-set-variable \
+-Wno-deprecated-non-prototype \
+-Wno-multichar \
 -Wno-unused-parameter \
 -Wno-missing-field-initializers \
 -I./$(INCDIR)
@@ -26,8 +28,8 @@ override LDFLAGS += # Nothing
 ### On macOS, include <argp.h> from Homebrew package `argp-standalone`
 ifneq ($(OS),Windows_NT)
 	ifeq ($(shell uname -s),Darwin)
-		override CFLAGS  += -I/usr/local/Cellar/argp-standalone/1.3/include/
-		override LDFLAGS += -L/usr/local/Cellar/argp-standalone/1.3/lib/ -largp
+                override CFLAGS  += -I/opt/homebrew/Cellar/argp-standalone/1.5.0/include/
+                override LDFLAGS += -L/opt/homebrew/Cellar/argp-standalone/1.5.0/lib/ -largp
 	endif
 endif
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Documentation for versioned releases and as generated from the `main` branch
   - On Ubuntu, ensure that the package `libc6-dev` is installed.
   
   - On macOS, you can install just Argp via the [Homebrew](https://brew.sh)
-    package `argp-standalone`. The Makefile will handle this configuration
+    package `argp-standalone`, with command `brew install argp-standalone`. The Makefile will handle this configuration
     automatically. If you acquire Argp any other way, such as by installing
     glibc in its entirety, you may need to configure `CFLAGS` and `LDFLAGS` as
     appropriate.

--- a/include/drat/io.h
+++ b/include/drat/io.h
@@ -11,7 +11,7 @@
 char* get_fopen_error_msg();
 char* get_fseeko_error_msg();
 
-int open_container__info_stream();
+int open_container__info_stream(FILE* info_stream);
 int open_container();
 int close_container();
 int end_of_container();


### PR DESCRIPTION
Some fixes thanks to https://github.com/PWhiddy/drat

- Detect `argp-standalone` version without hard coding it thanks to brew symlink
- Fix `int open_container__info_stream`
- Add `-Wno-unused-but-set-variable`
- Update README.md to include command to install `argp-standalone` in MAC